### PR TITLE
Bump Ruby 3.3.5 -> 3.3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@ RUN set -eux; \
 
 ENV LANG C.UTF-8
 
-# https://www.ruby-lang.org/en/news/2024/09/03/3-3-5-released/
-ENV RUBY_VERSION 3.3.5
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.5.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 51aec7ea89b46125a2c9adc6f36766b65023d47952b916b1aed300ddcc042359
+# https://www.ruby-lang.org/en/news/2026/07/16/ruby-3-3-12-released/
+ENV RUBY_VERSION 3.3.12
+ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.12.tar.xz
+ENV RUBY_DOWNLOAD_SHA256 873e3297990b8cff7a5436f6e510a3a7a18c74e5f2c794e4162e605fe0a743b3
 
 # VMB: libreadline-dev makes irb work much better
 


### PR DESCRIPTION
## Summary

`apiology/rubymegamix:latest` currently ships Ruby 3.3.5. Downstream
consumers building on top of it (e.g. `plate-spinner-rails`, whose
`Gemfile` requires `ruby '~> 3.3.6'`) fail `bundle install` during their
precache Docker builds with:

```
Your Ruby version is 3.3.5, but your Gemfile specified ~> 3.3.6
```

This bumps to 3.3.12, the latest patch release in the 3.3.x series as of
2026-07-30, rather than the bare 3.3.6 floor -- more bug/security fixes
for the same effort. SHA256 verified independently: downloaded the
tarball and computed the checksum locally rather than trusting the
release page.

## Test plan

- [ ] CI's `make build` step (runs on this PR, doesn't publish) confirms
      the image still builds cleanly with Ruby 3.3.12.
- [ ] After merge, confirm `apiology/rubymegamix:latest` picks up 3.3.12
      and that `plate-spinner-rails`'s precache build succeeds against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
